### PR TITLE
Baseline architecture

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/dataset
+/code/download_data.py

--- a/code/baseline.py
+++ b/code/baseline.py
@@ -1,0 +1,60 @@
+'''
+baseline.py
+
+This CNN model is designed to accept a fixed-sized image and
+pass it through a configurable number of both convolutional 
+and fully-connected layers in order to satisfy a mutli-class 
+classification.
+
+It uses pytorch as its fundamental library, taking advantage
+of its convolutional methods and neural net functioinality.
+
+The main purpose of this class is for construction of the 
+foundational model.  Regularization, training, and validation
+are handled in separate class files.
+
+Lukas Zumwalt
+3/1/2025
+'''
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+class BaselineCNN(nn.Module):
+    '''
+    Baseline Convolutional Neural Net.
+    '''
+    def __init__(self, num_classes=10):
+        super().__init__()
+
+        # Convolutional layers
+        self.conv1 = nn.Conv2d(in_channels=3, out_channels=32, kernel_size=3, stride=1, padding=1)
+        self.conv2 = nn.Conv2d(in_channels=32, out_channels=64, kernel_size=3, stride=1, padding=1)
+        self.conv3 = nn.Conv2d(in_channels=64, out_channels=128, kernel_size=3, stride=1, padding=1)
+
+        # Fully connected layers
+        self.fc1 = nn.Linear(128 * 8 * 8, 256)  # Adjust based on input image size
+        self.fc2 = nn.Linear(256, 128)
+        self.fc3 = nn.Linear(128, num_classes)
+
+        # Activation function
+        self.activation = nn.ReLU()
+
+    def forward(self, x):
+        '''
+        Forward Pass of parameters through activation functions
+        '''
+        x = self.activation(self.conv1(x))
+        x = self.activation(self.conv2(x))
+        x = self.activation(self.conv3(x))
+        x = F.adaptive_avg_pool2d(x, (8, 8))  # Ensure feature map fits FC layer
+        x = torch.flatten(x, start_dim=1)
+        x = self.activation(self.fc1(x))
+        x = self.activation(self.fc2(x))
+        x = self.fc3(x)  # No activation here; use Softmax in loss function
+        return x
+
+# Example Usage
+if __name__ == "__main__":
+    model = BaselineCNN(num_classes=10)
+    print(model)

--- a/code/baseline.py
+++ b/code/baseline.py
@@ -1,17 +1,20 @@
 '''
 baseline.py
 
-This CNN model is designed to accept a fixed-sized image and
-pass it through a configurable number of both convolutional 
+This CNN model is designed to accept fixed-sized images and
+pass them through a configurable number of both convolutional 
 and fully-connected layers in order to satisfy a mutli-class 
 classification.
 
 It uses pytorch as its fundamental library, taking advantage
 of its convolutional methods and neural net functioinality.
 
+Leaky ReLU is the primary activation function for neruons in
+this model, and softmax is used for the final layer.
+
 The main purpose of this class is for construction of the 
-foundational model.  Regularization, training, and validation
-are handled in separate class files.
+foundational model.  Rgularization, training, validation,
+and data access are handled in separate class files.
 
 Lukas Zumwalt
 3/1/2025
@@ -31,27 +34,45 @@ class BaselineCNN(nn.Module):
         self.conv1 = nn.Conv2d(in_channels=3, out_channels=32, kernel_size=3, stride=1, padding=1)
         self.conv2 = nn.Conv2d(in_channels=32, out_channels=64, kernel_size=3, stride=1, padding=1)
         self.conv3 = nn.Conv2d(in_channels=64, out_channels=128, kernel_size=3, stride=1, padding=1)
+        self.convos = [self.conv1, self.conv2, self.conv3]
 
         # Fully connected layers
         self.fc1 = nn.Linear(128 * 8 * 8, 256)  # Adjust based on input image size
         self.fc2 = nn.Linear(256, 128)
         self.fc3 = nn.Linear(128, num_classes)
+        self.fcs = [self.fc1, self.fc2, self.fc3]
 
         # Activation function
-        self.activation = nn.ReLU()
+        self.activation = nn.LeakyReLU()
 
     def forward(self, x):
         '''
-        Forward Pass of parameters through activation functions
+        Forward Pass of parameters through activation functions,
+        excepting the final fully-connected layer.
         '''
-        x = self.activation(self.conv1(x))
-        x = self.activation(self.conv2(x))
-        x = self.activation(self.conv3(x))
+        # Convolutional Layers:
+        # x = self.activation(self.conv1(x))
+        # x = self.activation(self.conv2(x))
+        # x = self.activation(self.conv3(x))
+        for c in self.convos:
+            x = self.activation(c(x))
+
+        # Formatting for FC, not learning:
         x = F.adaptive_avg_pool2d(x, (8, 8))  # Ensure feature map fits FC layer
         x = torch.flatten(x, start_dim=1)
-        x = self.activation(self.fc1(x))
-        x = self.activation(self.fc2(x))
-        x = self.fc3(x)  # No activation here; use Softmax in loss function
+
+        # Fully Connected Layers:
+        # x = self.activation(self.fc1(x))
+        # x = self.activation(self.fc2(x))
+        # x = self.fc3(x)  # No activation here; use Softmax in loss function
+        for i, f in self.fcs:
+            if i == len(self.fcs) - 1:
+                # Last FC layer, no activation.
+                # Implement softmax in the loss function.
+                x = f(x)
+            else:
+                x = self.activation(f(x))
+
         return x
 
 # Example Usage

--- a/run.bat
+++ b/run.bat
@@ -1,0 +1,6 @@
+@echo off
+echo Declaring Model...
+python code/baseline.py
+
+echo Done!
+pause


### PR DESCRIPTION
Sets up a baseline CNN with hard-coded dimensions, fixed layers, and a forward pass function.

Performs an example call to initialize a CNN model with 10 classes to identify.  This may be changed as desired in scripting.

Set up to run on windows with run.bat, but can run on unix by pulling out batch commands.